### PR TITLE
Using vagrant to bootstrap k8s examples

### DIFF
--- a/cluster1/up.sh
+++ b/cluster1/up.sh
@@ -7,6 +7,7 @@ sleep 60
 echo '######################## INITIALISING K8S RESOURCES ########################'
 chmod 400 certs/id_rsa
 vagrant ssh cluster1-master1 -c "sudo su - root -c 'kubectl apply -f /vagrant/k8s/init.yaml'"
+vagrant ssh cluster1-master1 -c "mkdir -p .kube ; sudo cp /root/.kube/config ./.kube/config ; sudo chown vagrant:vagrant .kube/config"
 sleep 20
 
 echo '######################## ALL DONE ########################'

--- a/cluster1/up.sh
+++ b/cluster1/up.sh
@@ -6,7 +6,7 @@ sleep 60
 
 echo '######################## INITIALISING K8S RESOURCES ########################'
 chmod 400 certs/id_rsa
-ssh-keygen -R 192.168.101.101; ssh root@192.168.101.101 -i certs/id_rsa -oStrictHostKeyChecking=no -- kubectl apply -f /vagrant/k8s/init.yaml
+vagrant ssh cluster1-master1 -c "sudo su - root -c 'kubectl apply -f /vagrant/k8s/init.yaml'"
 sleep 20
 
 echo '######################## ALL DONE ########################'


### PR DESCRIPTION
This has the benefit on relying specificly on Vagrant. Local network configs don't matter.

Additional improvements could be:
* Moving k8s config also to user vagrant
* Adding few kubectl aliases