### PR TITLE
Docker/K8s hard-coded versions & fixes

### DIFF
--- a/cluster1/scripts/install-kube.sh
+++ b/cluster1/scripts/install-kube.sh
@@ -10,9 +10,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y docker.io kubelet=1.18.2-00 kubeadm=1.18.2-00 kubectl=1.18.2-00 kubernetes-cni
-systemctl enable kubelet && systemctl start kubelet
-
+apt-get install -y docker.io=18.09.7-0ubuntu1~18.04.4 kubelet=1.18.2-00 kubeadm=1.18.2-00 kubectl=1.18.2-00 kubernetes-cni
 cat > /etc/docker/daemon.json <<EOF
 {
   "exec-opts": ["native.cgroupdriver=systemd"],
@@ -20,14 +18,18 @@ cat > /etc/docker/daemon.json <<EOF
   "storage-driver": "overlay2"
 }
 EOF
-
 mkdir -p /etc/systemd/system/docker.service.d
 
 # Restart docker.
 systemctl daemon-reload
-systemctl enable docker && systemctl start docker
+systemctl restart docker
 
-docker info | grep overlay
-docker info | grep systemd
+# start docker on reboot
+systemctl enable docker
+
+docker info | grep -i "storage"
+docker info | grep -i "cgroup"
+
+systemctl enable kubelet && systemctl start kubelet
 
 exit 0

--- a/cluster1/scripts/install-master.sh
+++ b/cluster1/scripts/install-master.sh
@@ -3,7 +3,7 @@ apt-get update
 apt-get install -y etcd-client
 
 kubeadm reset -f
-kubeadm init --apiserver-advertise-address=$MASTER_IP --pod-network-cidr=$POD_NW_CIDR
+kubeadm init --kubernetes-version=1.18.2 --apiserver-advertise-address=$MASTER_IP --pod-network-cidr=$POD_NW_CIDR
 kubeadm token create --print-join-command --ttl 0 > /vagrant/tmp/master-join-command.sh
 
 mkdir -p $HOME/.kube


### PR DESCRIPTION
1. Hard-coded supported docker version
2. Waiting until docker is appropriately configured before starting kube components
3. Issuing 'restart' instead of 'start' to properly configure docker options
4. Hard-coding kubernetes version (instead of using default 'stable-1') in kubeadm init so you can validate all the configuraiton is correct in this repo, and also, people get to practice things like cluster upgrades.