### PR TITLE
Fix install error for docker.io

### DIFF
--- a/cluster1/scripts/install-kube.sh
+++ b/cluster1/scripts/install-kube.sh
@@ -10,7 +10,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y docker.io=18.09.7-0ubuntu1~18.04.4 kubelet=1.18.2-00 kubeadm=1.18.2-00 kubectl=1.18.2-00 kubernetes-cni
+apt-get install -y docker.io=19.03.6-0ubuntu1~18.04.2 kubelet=1.18.2-00 kubeadm=1.18.2-00 kubectl=1.18.2-00 kubernetes-cni
 cat > /etc/docker/daemon.json <<EOF
 {
   "exec-opts": ["native.cgroupdriver=systemd"],


### PR DESCRIPTION
docker.io=18.09.7-0ubuntu1~18.04.4 no longer available in repo.  Install won't complete.

```
vagrant@cluster1-master1:~$ apt-cache madison docker.io
 docker.io | 19.03.6-0ubuntu1~18.04.2 | http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages
 docker.io | 19.03.6-0ubuntu1~18.04.2 | http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages
 docker.io | 17.12.1-0ubuntu1 | http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages
```