### PR TITLE
Issue8 - Use configmap suggestion

### DIFF
--- a/cluster1/k8s/init.yaml
+++ b/cluster1/k8s/init.yaml
@@ -274,8 +274,47 @@ spec:
   containers:
   - image: nginx:1.16.1-alpine
     name: nginx
+    volumeMounts:
+    - name: configmap-nginx-conf
+      mountPath: /etc/nginx/
   - image: httpd:2.4.41-alpine
     name: httpd
   dnsPolicy: ClusterFirst
   restartPolicy: Never
+  volumes:
+  - name: configmap-nginx-conf
+    configMap:
+      name: nginx-conf
 status: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: management
+data:
+  nginx.conf: |
+    user                            root;
+    worker_processes                auto;
+
+    error_log                       /var/log/nginx/error.log warn;
+
+    events {
+        worker_connections          1024;
+    }
+
+    http {
+        default_type                application/octet-stream;
+        sendfile                    off;
+        access_log                  off;
+        keepalive_timeout           3000;
+        server {
+            listen                  80;
+            root                    /usr/share/nginx/html;
+            index                   index.html;
+            server_name             localhost;
+            client_max_body_size    16m;
+        }
+    }
+
+

--- a/cluster1/k8s/init.yaml
+++ b/cluster1/k8s/init.yaml
@@ -148,7 +148,7 @@ spec:
         run: what-a-deployment
     spec:
       containers:
-      - image: nginx:1.17.6-alpine
+      - image: nginx:1.21-alpine
         name: what-a-deployment
         resources: {}
 ---
@@ -255,7 +255,7 @@ metadata:
   namespace: management
 spec:
   containers:
-  - image: nginx:1.16.1-alpine
+  - image: nginx:1.21-alpine
     name: important
   dnsPolicy: ClusterFirst
   priorityClassName: high-priority-important
@@ -272,7 +272,7 @@ metadata:
   namespace: management
 spec:
   containers:
-  - image: nginx:1.16.1-alpine
+  - image: nginx:1.21-alpine
     name: nginx
     volumeMounts:
     - name: configmap-nginx-conf

--- a/cluster1/k8s/resources/namespaces/management/web-server.yaml
+++ b/cluster1/k8s/resources/namespaces/management/web-server.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: management
 spec:
   containers:
-  - image: nginx:1.16.1-alpine
+  - image: nginx:1.21.6-alpine
     name: nginx
     volumeMounts:
     - name: configmap-nginx-conf

--- a/cluster1/k8s/resources/namespaces/management/web-server.yaml
+++ b/cluster1/k8s/resources/namespaces/management/web-server.yaml
@@ -10,8 +10,46 @@ spec:
   containers:
   - image: nginx:1.16.1-alpine
     name: nginx
+    volumeMounts:
+    - name: configmap-nginx-conf
+      mountPath: /etc/nginx/
   - image: httpd:2.4.41-alpine
     name: httpd
   dnsPolicy: ClusterFirst
   restartPolicy: Never
+  volumes:
+  - name: configmap-nginx-conf
+    configMap:
+      name: nginx-conf
 status: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: management
+data:
+  nginx.conf: |
+    user                            root;
+    worker_processes                auto;
+
+    error_log                       /var/log/nginx/error.log warn;
+
+    events {
+        worker_connections          1024;
+    }
+
+    http {
+        default_type                application/octet-stream;
+        sendfile                    off;
+        access_log                  off;
+        keepalive_timeout           3000;
+        server {
+            listen                  80;
+            root                    /usr/share/nginx/html;
+            index                   index.html;
+            server_name             localhost;
+            client_max_body_size    16m;
+        }
+    }
+


### PR DESCRIPTION
This PR includes a configmap for the nginx container in the first exercise. This is to address the suggestion in #8 

Essentially, this doesn't change the exercise and the troubleshooting which leads up to it but does provide the ability to the participant to solve the erroring container. 

The solution to question 5 in the first exercise would now be:

1. Edit the configmap so the nginx container listens on port other than 80 (eg `kubectl edit`)
2. Output pod def (eg, `k describe pod web-server -o yaml > pod.yaml`)
3. Delete `web-server` pod (`k delete pod web-server`)
4. Create new `web-server` pod (k apply -f pod.yaml`) 

